### PR TITLE
Standardize PDF export directory

### DIFF
--- a/exports/__init__.py
+++ b/exports/__init__.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+EXPORT_DIR = Path("exports/out")
+EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+__all__ = ["EXPORT_DIR"]

--- a/exports/pdf_export.py
+++ b/exports/pdf_export.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 from fpdf import FPDF
 from models.rechnung import Rechnung
 from models.kunde import Kunde
 from models.position import Position
+
+from . import EXPORT_DIR
 
 class PDFExporter:
     def __init__(self, rechnung: Rechnung):
@@ -66,9 +70,19 @@ class PDFExporter:
         summe_line("Bruttobetrag:", brutto)
 
 
-    def export(self, pfad="rechnung.pdf"):
+    def export(self, pfad: str | Path | None = None) -> Path:
         self.add_header()
         self.add_kundendaten()
         self.add_positionen()
         self.add_summe()
-        self.pdf.output(pfad)
+        if pfad is None:
+            pfad = Path("rechnung.pdf")
+
+        pfad = Path(pfad)
+        if not pfad.is_absolute():
+            pfad = EXPORT_DIR / pfad
+
+        pfad.parent.mkdir(parents=True, exist_ok=True)
+
+        self.pdf.output(str(pfad))
+        return pfad

--- a/gui/rechnung_gui.py
+++ b/gui/rechnung_gui.py
@@ -159,11 +159,10 @@ def erstelle_pdf():
         rechnungsnummer = lese_und_aktualisiere_rechnungsnummer()
         rechnung = Rechnung(rechnungsnummer, kunde, positionen_liste)
 
-        os.makedirs("tests", exist_ok=True)
         exporter = PDFExporter(rechnung)
-        exporter.export("tests/rechnung_gui.pdf")
+        pdf_path = exporter.export(f"rechnung_{rechnungsnummer}.pdf")
 
-        messagebox.showinfo("Erfolg", "PDF wurde erstellt: tests/rechnung_gui.pdf")
+        messagebox.showinfo("Erfolg", f"PDF wurde erstellt: {pdf_path}")
     except Exception as e:
         messagebox.showerror("Fehler", str(e))
 

--- a/tests/rechnung_gui.py
+++ b/tests/rechnung_gui.py
@@ -172,11 +172,10 @@ def erstelle_pdf():
         kunde = Kunde(name, "", strasse, plz_ort[0], " ".join(plz_ort[1:]))
         rechnung = Rechnung("2025-001", kunde, positionen_liste)
 
-        os.makedirs("tests", exist_ok=True)
         exporter = PDFExporter(rechnung)
-        exporter.export("tests/rechnung_gui.pdf")
+        pdf_path = exporter.export("rechnung_gui.pdf")
 
-        messagebox.showinfo("Erfolg", "PDF wurde erstellt: tests/rechnung_gui.pdf")
+        messagebox.showinfo("Erfolg", f"PDF wurde erstellt: {pdf_path}")
     except Exception as e:
         messagebox.showerror("Fehler", str(e))
 

--- a/tests/test_rechnung.py
+++ b/tests/test_rechnung.py
@@ -36,4 +36,4 @@ print(rechnung)
 from exports.pdf_export import PDFExporter
 
 pdf_export = PDFExporter(rechnung)
-pdf_export.export("tests/test_rechnung.pdf")
+pdf_export.export("test_rechnung.pdf")


### PR DESCRIPTION
## Summary
- introduce a shared `EXPORT_DIR` that always points to `exports/out`
- update the PDF exporter to resolve export destinations against the shared directory
- adjust GUI flows and regression scripts to use the new export location and report the generated path

## Testing
- python -m compileall exports gui tests

------
https://chatgpt.com/codex/tasks/task_b_690985db4220832786cbc989a5a9bf6c