### PR TITLE
Initial invoice_app skeleton: PySide6 GUI, SQLAlchemy models, and entrypoint

### DIFF
--- a/invoice_app/__init__.py
+++ b/invoice_app/__init__.py
@@ -1,0 +1,1 @@
+"""Invoice desktop application package."""

--- a/invoice_app/app.py
+++ b/invoice_app/app.py
@@ -1,0 +1,13 @@
+import sys
+from PySide6.QtWidgets import QApplication
+
+from invoice_app.database.init_db import init_database
+from invoice_app.ui.main_window import MainWindow
+
+
+def run() -> int:
+    init_database()
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    return app.exec()

--- a/invoice_app/database/base.py
+++ b/invoice_app/database/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/invoice_app/database/init_db.py
+++ b/invoice_app/database/init_db.py
@@ -1,0 +1,12 @@
+from invoice_app.database.base import Base
+from invoice_app.database.session import engine
+from invoice_app.models.app_settings import AppSettings
+from invoice_app.models.customer import Customer
+from invoice_app.models.invoice import Invoice
+from invoice_app.models.invoice_item import InvoiceItem
+
+
+def init_database() -> None:
+    # Imports above ensure all models are registered in metadata.
+    _ = (AppSettings, Customer, Invoice, InvoiceItem)
+    Base.metadata.create_all(bind=engine)

--- a/invoice_app/database/session.py
+++ b/invoice_app/database/session.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DB_PATH = Path(__file__).resolve().parents[2] / "daten" / "invoice_app.db"
+DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+engine = create_engine(f"sqlite:///{DB_PATH}", echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)

--- a/invoice_app/models/__init__.py
+++ b/invoice_app/models/__init__.py
@@ -1,0 +1,6 @@
+from invoice_app.models.app_settings import AppSettings
+from invoice_app.models.customer import Customer
+from invoice_app.models.invoice import Invoice
+from invoice_app.models.invoice_item import InvoiceItem
+
+__all__ = ["Customer", "Invoice", "InvoiceItem", "AppSettings"]

--- a/invoice_app/models/app_settings.py
+++ b/invoice_app/models/app_settings.py
@@ -1,0 +1,11 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from invoice_app.database.base import Base
+
+
+class AppSettings(Base):
+    __tablename__ = "app_settings"
+
+    key: Mapped[str] = mapped_column(String(100), primary_key=True)
+    value: Mapped[str] = mapped_column(String(1000), nullable=False)

--- a/invoice_app/models/customer.py
+++ b/invoice_app/models/customer.py
@@ -1,0 +1,16 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from invoice_app.database.base import Base
+
+
+class Customer(Base):
+    __tablename__ = "customers"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    address: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    invoices = relationship("Invoice", back_populates="customer", cascade="all, delete-orphan")

--- a/invoice_app/models/invoice.py
+++ b/invoice_app/models/invoice.py
@@ -1,0 +1,21 @@
+from datetime import date, datetime
+from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from invoice_app.database.base import Base
+
+
+class Invoice(Base):
+    __tablename__ = "invoices"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    number: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    customer_id: Mapped[int] = mapped_column(ForeignKey("customers.id"), nullable=False)
+    invoice_date: Mapped[date] = mapped_column(Date, nullable=False)
+    due_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    total_amount: Mapped[float] = mapped_column(Numeric(10, 2), default=0)
+    status: Mapped[str] = mapped_column(String(30), default="draft")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    customer = relationship("Customer", back_populates="invoices")
+    items = relationship("InvoiceItem", back_populates="invoice", cascade="all, delete-orphan")

--- a/invoice_app/models/invoice_item.py
+++ b/invoice_app/models/invoice_item.py
@@ -1,0 +1,16 @@
+from sqlalchemy import ForeignKey, Numeric, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from invoice_app.database.base import Base
+
+
+class InvoiceItem(Base):
+    __tablename__ = "invoice_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    invoice_id: Mapped[int] = mapped_column(ForeignKey("invoices.id"), nullable=False)
+    description: Mapped[str] = mapped_column(String(255), nullable=False)
+    quantity: Mapped[float] = mapped_column(Numeric(10, 2), default=1)
+    unit_price: Mapped[float] = mapped_column(Numeric(10, 2), default=0)
+
+    invoice = relationship("Invoice", back_populates="items")

--- a/invoice_app/pages/__init__.py
+++ b/invoice_app/pages/__init__.py
@@ -1,0 +1,3 @@
+from invoice_app.pages.simple_page import SimplePage
+
+__all__ = ["SimplePage"]

--- a/invoice_app/pages/simple_page.py
+++ b/invoice_app/pages/simple_page.py
@@ -1,0 +1,15 @@
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class SimplePage(QWidget):
+    def __init__(self, title: str, description: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+
+        heading = QLabel(f"<h2>{title}</h2>")
+        text = QLabel(description)
+        text.setWordWrap(True)
+
+        layout.addWidget(heading)
+        layout.addWidget(text)
+        layout.addStretch(1)

--- a/invoice_app/ui/main_window.py
+++ b/invoice_app/ui/main_window.py
@@ -1,0 +1,48 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QListWidget,
+    QListWidgetItem,
+    QMainWindow,
+    QStackedWidget,
+    QWidget,
+)
+
+from invoice_app.pages.simple_page import SimplePage
+
+
+class MainWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Invoice App")
+        self.resize(1100, 700)
+
+        container = QWidget(self)
+        layout = QHBoxLayout(container)
+
+        self.navigation = QListWidget()
+        self.navigation.setFixedWidth(220)
+        self.navigation.setSpacing(4)
+
+        self.pages = QStackedWidget()
+
+        sections = [
+            ("Überblick", "Dashboard mit wichtigsten Kennzahlen und Schnellaktionen."),
+            ("Kunden", "Verwaltung von Kundenstammdaten und Kontakten."),
+            ("Rechnungen", "Erstellung und Bearbeitung von Rechnungen."),
+            ("Archiv", "Historie abgeschlossener und exportierter Rechnungen."),
+            ("Einstellungen", "App-Einstellungen, Nummernkreise und Standardwerte."),
+        ]
+
+        for title, description in sections:
+            self.navigation.addItem(QListWidgetItem(title))
+            self.pages.addWidget(SimplePage(title, description))
+
+        self.navigation.currentRowChanged.connect(self.pages.setCurrentIndex)
+        self.navigation.setCurrentRow(0)
+
+        layout.addWidget(self.navigation)
+        layout.addWidget(self.pages, 1)
+        self.setCentralWidget(container)
+        self.statusBar().showMessage("Bereit", 3000)
+        self.navigation.setFocusPolicy(Qt.FocusPolicy.NoFocus)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from invoice_app.app import run
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ defusedxml==0.7.1
 fonttools==4.57.0
 fpdf2==2.8.3
 pillow==11.2.1
+PySide6
+SQLAlchemy
+reportlab


### PR DESCRIPTION
### Motivation

- Provide a starting desktop application structure for an invoice app with a GUI and persistence layer.
- Define core domain models and a local SQLite backend so the app can store invoices, customers, items, and settings.
- Add a simple navigable UI to inspect pages and serve as a basis for building features like invoice creation and export.
- Add an application entrypoint and explicit runtime requirements to make the app runnable.

### Description

- Added the package scaffold and entrypoint with `main.py` and `invoice_app/app.py` exposing `run()` which calls `init_database()` and starts a `QApplication`.
- Implemented SQLAlchemy base, session, and initialization in `invoice_app/database/base.py`, `session.py`, and `init_db.py`, with the SQLite file created at `daten/invoice_app.db` via `engine` in `session.py`.
- Added domain models `Customer`, `Invoice`, `InvoiceItem`, and `AppSettings` under `invoice_app/models/` with relationships and mapped columns and registered them via `invoice_app/models/__init__.py`.
- Implemented a minimal PySide6 UI including `invoice_app/ui/main_window.py` and a reusable `SimplePage` in `invoice_app/pages/`, and updated `requirements.txt` to include `PySide6`, `SQLAlchemy`, and `reportlab`.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05cf9f5aa08323a71c07f4318af84d)