### PR TITLE
Phase 2: Kundenverwaltung mit CustomersPage, Dialog, Service & Repository

### DIFF
--- a/invoice_app/dialogs/customer_dialog.py
+++ b/invoice_app/dialogs/customer_dialog.py
@@ -1,0 +1,62 @@
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class CustomerDialog(QDialog):
+    def __init__(self, parent: QWidget | None = None, customer: object | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Kunde bearbeiten" if customer else "Neuer Kunde")
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.customer_number_edit = QLineEdit()
+        self.name_edit = QLineEdit()
+        self.street_edit = QLineEdit()
+        self.postal_code_edit = QLineEdit()
+        self.city_edit = QLineEdit()
+        self.email_edit = QLineEdit()
+        self.phone_edit = QLineEdit()
+
+        form.addRow("Kundennummer", self.customer_number_edit)
+        form.addRow("Name", self.name_edit)
+        form.addRow("Straße", self.street_edit)
+        form.addRow("PLZ", self.postal_code_edit)
+        form.addRow("Ort", self.city_edit)
+        form.addRow("E-Mail", self.email_edit)
+        form.addRow("Telefon", self.phone_edit)
+
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Save | QDialogButtonBox.StandardButton.Cancel)
+        buttons.button(QDialogButtonBox.StandardButton.Save).setText("Speichern")
+        buttons.button(QDialogButtonBox.StandardButton.Cancel).setText("Abbrechen")
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        if customer:
+            self.customer_number_edit.setText(customer.customer_number or "")
+            self.name_edit.setText(customer.name or "")
+            self.street_edit.setText(customer.street or "")
+            self.postal_code_edit.setText(customer.postal_code or "")
+            self.city_edit.setText(customer.city or "")
+            self.email_edit.setText(customer.email or "")
+            self.phone_edit.setText(customer.phone or "")
+
+    def get_data(self) -> dict:
+        return {
+            "customer_number": self.customer_number_edit.text(),
+            "name": self.name_edit.text(),
+            "street": self.street_edit.text(),
+            "postal_code": self.postal_code_edit.text(),
+            "city": self.city_edit.text(),
+            "email": self.email_edit.text(),
+            "phone": self.phone_edit.text(),
+        }

--- a/invoice_app/models/customer.py
+++ b/invoice_app/models/customer.py
@@ -8,9 +8,12 @@ class Customer(Base):
     __tablename__ = "customers"
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    customer_number: Mapped[str] = mapped_column(String(50), nullable=False)
     name: Mapped[str] = mapped_column(String(200), nullable=False)
+    street: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    postal_code: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    city: Mapped[str | None] = mapped_column(String(120), nullable=True)
     email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     phone: Mapped[str | None] = mapped_column(String(50), nullable=True)
-    address: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     invoices = relationship("Invoice", back_populates="customer", cascade="all, delete-orphan")

--- a/invoice_app/pages/customers_page.py
+++ b/invoice_app/pages/customers_page.py
@@ -1,0 +1,177 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from invoice_app.dialogs.customer_dialog import CustomerDialog
+from invoice_app.services.customer_service import CustomerService
+
+
+class CustomersPage(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.service = CustomerService()
+        self.customers = []
+
+        root_layout = QVBoxLayout(self)
+
+        self.table = QTableWidget(0, 8)
+        self.table.setHorizontalHeaderLabels([
+            "ID", "Kundennummer", "Name", "Straße", "PLZ", "Ort", "E-Mail", "Telefon"
+        ])
+        self.table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
+        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.table.itemSelectionChanged.connect(self.show_selected_details)
+
+        root_layout.addWidget(self.table)
+
+        button_layout = QHBoxLayout()
+        self.new_button = QPushButton("Neu")
+        self.edit_button = QPushButton("Bearbeiten")
+        self.delete_button = QPushButton("Löschen")
+        self.refresh_button = QPushButton("Aktualisieren")
+        button_layout.addWidget(self.new_button)
+        button_layout.addWidget(self.edit_button)
+        button_layout.addWidget(self.delete_button)
+        button_layout.addStretch(1)
+        button_layout.addWidget(self.refresh_button)
+        root_layout.addLayout(button_layout)
+
+        detail_box = QWidget()
+        self.detail_form = QFormLayout(detail_box)
+        self.detail_labels: dict[str, QLabel] = {}
+        for key, text in [
+            ("id", "ID"),
+            ("customer_number", "Kundennummer"),
+            ("name", "Name"),
+            ("street", "Straße"),
+            ("postal_code", "PLZ"),
+            ("city", "Ort"),
+            ("email", "E-Mail"),
+            ("phone", "Telefon"),
+        ]:
+            label = QLabel("-")
+            label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+            self.detail_form.addRow(f"{text}:", label)
+            self.detail_labels[key] = label
+        root_layout.addWidget(detail_box)
+
+        self.new_button.clicked.connect(self.create_customer)
+        self.edit_button.clicked.connect(self.edit_customer)
+        self.delete_button.clicked.connect(self.delete_customer)
+        self.refresh_button.clicked.connect(self.load_customers)
+
+        self.load_customers()
+
+    def load_customers(self) -> None:
+        try:
+            self.customers = self.service.list_customers()
+        except Exception as error:
+            QMessageBox.critical(self, "Fehler", f"Kunden konnten nicht geladen werden:\n{error}")
+            return
+
+        self.table.setRowCount(len(self.customers))
+        for row, customer in enumerate(self.customers):
+            values = [
+                customer.id,
+                customer.customer_number,
+                customer.name,
+                customer.street or "",
+                customer.postal_code or "",
+                customer.city or "",
+                customer.email or "",
+                customer.phone or "",
+            ]
+            for column, value in enumerate(values):
+                self.table.setItem(row, column, QTableWidgetItem(str(value)))
+
+        if self.customers:
+            self.table.selectRow(0)
+            self.show_customer_details(self.customers[0])
+        else:
+            self.clear_details()
+
+    def get_selected_customer_id(self) -> int | None:
+        row = self.table.currentRow()
+        if row < 0 or row >= len(self.customers):
+            return None
+        return self.customers[row].id
+
+    def show_selected_details(self) -> None:
+        customer_id = self.get_selected_customer_id()
+        if customer_id is None:
+            self.clear_details()
+            return
+        customer = next((c for c in self.customers if c.id == customer_id), None)
+        if customer:
+            self.show_customer_details(customer)
+
+    def show_customer_details(self, customer) -> None:
+        self.detail_labels["id"].setText(str(customer.id))
+        self.detail_labels["customer_number"].setText(customer.customer_number or "-")
+        self.detail_labels["name"].setText(customer.name or "-")
+        self.detail_labels["street"].setText(customer.street or "-")
+        self.detail_labels["postal_code"].setText(customer.postal_code or "-")
+        self.detail_labels["city"].setText(customer.city or "-")
+        self.detail_labels["email"].setText(customer.email or "-")
+        self.detail_labels["phone"].setText(customer.phone or "-")
+
+    def clear_details(self) -> None:
+        for label in self.detail_labels.values():
+            label.setText("-")
+
+    def create_customer(self) -> None:
+        dialog = CustomerDialog(self)
+        if dialog.exec():
+            try:
+                self.service.create_customer(dialog.get_data())
+                self.load_customers()
+            except Exception as error:
+                QMessageBox.critical(self, "Fehler", str(error))
+
+    def edit_customer(self) -> None:
+        customer_id = self.get_selected_customer_id()
+        if customer_id is None:
+            QMessageBox.information(self, "Hinweis", "Bitte zuerst einen Kunden auswählen.")
+            return
+        customer = next((c for c in self.customers if c.id == customer_id), None)
+        if customer is None:
+            return
+        dialog = CustomerDialog(self, customer)
+        if dialog.exec():
+            try:
+                self.service.update_customer(customer_id, dialog.get_data())
+                self.load_customers()
+            except Exception as error:
+                QMessageBox.critical(self, "Fehler", str(error))
+
+    def delete_customer(self) -> None:
+        customer_id = self.get_selected_customer_id()
+        if customer_id is None:
+            QMessageBox.information(self, "Hinweis", "Bitte zuerst einen Kunden auswählen.")
+            return
+
+        confirm = QMessageBox.question(
+            self,
+            "Kunde löschen",
+            "Möchten Sie den ausgewählten Kunden wirklich löschen?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if confirm != QMessageBox.StandardButton.Yes:
+            return
+
+        try:
+            self.service.delete_customer(customer_id)
+            self.load_customers()
+        except Exception as error:
+            QMessageBox.critical(self, "Fehler", str(error))

--- a/invoice_app/repositories/customer_repository.py
+++ b/invoice_app/repositories/customer_repository.py
@@ -1,0 +1,31 @@
+from sqlalchemy import select
+
+from invoice_app.models.customer import Customer
+
+
+class CustomerRepository:
+    def __init__(self, session) -> None:
+        self.session = session
+
+    def list_customers(self) -> list[Customer]:
+        stmt = select(Customer).order_by(Customer.name.asc())
+        return list(self.session.scalars(stmt).all())
+
+    def get_customer(self, customer_id: int) -> Customer | None:
+        return self.session.get(Customer, customer_id)
+
+    def create_customer(self, data: dict) -> Customer:
+        customer = Customer(**data)
+        self.session.add(customer)
+        self.session.flush()
+        return customer
+
+    def update_customer(self, customer: Customer, data: dict) -> Customer:
+        for key, value in data.items():
+            setattr(customer, key, value)
+        self.session.flush()
+        return customer
+
+    def delete_customer(self, customer: Customer) -> None:
+        self.session.delete(customer)
+        self.session.flush()

--- a/invoice_app/services/customer_service.py
+++ b/invoice_app/services/customer_service.py
@@ -1,0 +1,78 @@
+from invoice_app.database.session import SessionLocal
+from invoice_app.repositories.customer_repository import CustomerRepository
+
+
+class CustomerService:
+    @staticmethod
+    def _clean(value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+    def _validate(self, data: dict) -> None:
+        if not data.get("name"):
+            raise ValueError("Name darf nicht leer sein.")
+        if not data.get("customer_number"):
+            raise ValueError("Kundennummer darf nicht leer sein.")
+
+        email = data.get("email")
+        if email and "@" not in email:
+            raise ValueError("E-Mail muss ein @ enthalten.")
+
+        postal_code = data.get("postal_code")
+        if postal_code and not postal_code.isdigit():
+            raise ValueError("PLZ darf nur Zahlen enthalten.")
+
+    def _normalize_payload(self, data: dict) -> dict:
+        payload = {
+            "customer_number": self._clean(data.get("customer_number")) or "",
+            "name": self._clean(data.get("name")) or "",
+            "street": self._clean(data.get("street")),
+            "postal_code": self._clean(data.get("postal_code")),
+            "city": self._clean(data.get("city")),
+            "email": self._clean(data.get("email")),
+            "phone": self._clean(data.get("phone")),
+        }
+        self._validate(payload)
+        return payload
+
+    def list_customers(self):
+        with SessionLocal() as session:
+            repo = CustomerRepository(session)
+            return repo.list_customers()
+
+    def get_customer(self, customer_id: int):
+        with SessionLocal() as session:
+            repo = CustomerRepository(session)
+            return repo.get_customer(customer_id)
+
+    def create_customer(self, data: dict):
+        payload = self._normalize_payload(data)
+        with SessionLocal() as session:
+            repo = CustomerRepository(session)
+            customer = repo.create_customer(payload)
+            session.commit()
+            session.refresh(customer)
+            return customer
+
+    def update_customer(self, customer_id: int, data: dict):
+        payload = self._normalize_payload(data)
+        with SessionLocal() as session:
+            repo = CustomerRepository(session)
+            customer = repo.get_customer(customer_id)
+            if customer is None:
+                raise ValueError("Kunde wurde nicht gefunden.")
+            updated = repo.update_customer(customer, payload)
+            session.commit()
+            session.refresh(updated)
+            return updated
+
+    def delete_customer(self, customer_id: int):
+        with SessionLocal() as session:
+            repo = CustomerRepository(session)
+            customer = repo.get_customer(customer_id)
+            if customer is None:
+                raise ValueError("Kunde wurde nicht gefunden.")
+            repo.delete_customer(customer)
+            session.commit()

--- a/invoice_app/ui/main_window.py
+++ b/invoice_app/ui/main_window.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from invoice_app.pages.customers_page import CustomersPage
 from invoice_app.pages.simple_page import SimplePage
 
 
@@ -34,9 +35,12 @@ class MainWindow(QMainWindow):
             ("Einstellungen", "App-Einstellungen, Nummernkreise und Standardwerte."),
         ]
 
-        for title, description in sections:
+        for index, (title, description) in enumerate(sections):
             self.navigation.addItem(QListWidgetItem(title))
-            self.pages.addWidget(SimplePage(title, description))
+            if index == 1:
+                self.pages.addWidget(CustomersPage())
+            else:
+                self.pages.addWidget(SimplePage(title, description))
 
         self.navigation.currentRowChanged.connect(self.pages.setCurrentIndex)
         self.navigation.setCurrentRow(0)


### PR DESCRIPTION
### Motivation
- Die Platzhalter-Seite für „Kunden“ soll durch eine echte Kundenverwaltung ersetzt werden, die GUI-Logik von Datenzugriff trennt und CRUD-Funktionalität bietet.

### Description
- Ersetzt den Navigationspunkt „Kunden“ durch `CustomersPage`, die eine Tabelle mit den Spalten `ID`, `Kundennummer`, `Name`, `Straße`, `PLZ`, `Ort`, `E-Mail`, `Telefon` sowie Buttons `Neu`, `Bearbeiten`, `Löschen`, `Aktualisieren` und einen Detailbereich für die Auswahl enthält.
- Fügt `CustomerDialog` zum Anlegen/Bearbeiten mit Feldern `customer_number`, `name`, `street`, `postal_code`, `city`, `email`, `phone` und Buttons `Speichern`/`Abbrechen` hinzu.
- Implementiert `CustomerService` (Validierung, Normalisierung) mit Methoden `list_customers()`, `get_customer()`, `create_customer()`, `update_customer()` und `delete_customer()` und ein `CustomerRepository` für SQLAlchemy-Zugriff, sodass die GUI nur `CustomerService` aufruft.
- Aktualisiert das `Customer`-Modell um `customer_number`, `street`, `postal_code`, `city` und entfernt das alte `address`-Feld, sowie Verbindung von Service -> Repository -> DB implementiert.

### Testing
- Automatischer Kompilier-Test `python -m compileall main.py invoice_app` wurde ausgeführt und hat erfolgreich kompiliert.
- Geänderte/neu erstellte Dateien: `invoice_app/ui/main_window.py` (geändert), `invoice_app/models/customer.py` (geändert), `invoice_app/pages/customers_page.py` (neu), `invoice_app/dialogs/customer_dialog.py` (neu), `invoice_app/services/customer_service.py` (neu), `invoice_app/repositories/customer_repository.py` (neu).
- Lokale manuelle Tests: App starten mit `python main.py`, Navigation auf `Kunden` wählen, prüfen dass die Tabelle lädt, `Neu` öffnet leeren Dialog und speichert, `Bearbeiten` öffnet vorbelegten Dialog, `Löschen` fragt per `QMessageBox` und nach Speichern/Löschen die Tabelle aktualisiert wird.
- Validierungsfälle prüfen: leerer `Name`/`Kundennummer` zeigt Fehler, `E-Mail` ohne `@` zeigt Fehler, `PLZ` mit nicht-numerischen Zeichen zeigt Fehler.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05d8ffa0188323b2c3c78544782eb7)